### PR TITLE
[#8] README에 뽀모도로 설계 다이어그램 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,63 @@ iOS Pomodoro &amp; Routine App with SwiftUI and Combine.
 - [피그마 디자인 문서](https://www.figma.com/design/brJLUMcaCD3115jvg6KQ9M/HoneyRoutine?node-id=0-1&t=KYYdk14TlM1iP6Rc-1) 
 - [피그마 유저 플로우 문서](https://www.figma.com/board/lZwOMVJyVZJ67qzs2XEz0M/HoneyRoutine-Planning?node-id=0-1&t=Bmst8jYcrnBnprfd-1)
 ---
+
+## 6. Pomodoro Timer 설계 다이어그램
+
+```mermaid
+graph TD;
+  subgraph Presentation Layer
+    TimerView["🖼 TimerView (SwiftUI)"]
+    TimerViewModel["⚙️ TimerViewModel (Combine)
+    - startTimer()
+    - stopTimer()
+    - resetTimer()
+    - updateRemainingTime()
+    - bindToUseCase()"]
+    TimerVC["📱 TimerViewController (Optional)"]
+  end
+
+  subgraph Domain Layer
+    TimerUseCase["🛠 TimerUseCase
+    - startTimer(duration: Int)
+    - stopTimer()
+    - resetTimer()
+    - getCurrentTimer() -> TimerEntity?
+    - updateRemainingTime(time: Int)"]
+    
+    TimerRepositoryProtocol["🔌 TimerRepositoryProtocol
+    - saveTimer(_ timer: TimerEntity)
+    - loadTimer() -> TimerEntity?
+    - clearTimer()"]
+    
+    TimerEntity["🗂 TimerEntity
+    - duration: Int
+    - remainingTime: Int
+    - isRunning: Bool"]
+    
+    TimerProtocol["⏳ TimerProtocol
+    - start(duration: Int)
+    - stop()
+    - reset()
+    - remainingTimerObservable: Observable<Int> (Combine 문법으로 변경 필요)"]
+  end
+
+  subgraph Data Layer
+    TimerRepository["💾 TimerRepository
+    - saveTimer(_ timer: TimerEntity)
+    - loadTimer() -> TimerEntity?
+    - clearTimer()"]
+    
+    TimerLocalDataBase["📂 TimerLocalDataBase
+    - saveTimer(_ timer: TimerEntity)
+    - loadTimer() -> TimerEntity?
+    - clearTimer()"]
+  end
+
+  %% 연결 관계 설정
+  TimerView -->|데이터 바인딩| TimerViewModel
+  TimerViewModel -->|UseCase 호출| TimerUseCase
+  TimerUseCase -->|타이머 동작| TimerProtocol
+  TimerUseCase -->|데이터 저장/불러오기| TimerRepositoryProtocol
+  TimerRepositoryProtocol -->|실제 구현| TimerRepository
+  TimerRepository -->|데이터 저장/로드| TimerLocalDataBase


### PR DESCRIPTION
## 📝 작업 내용

- README에 뽀모도로 기능 설계 다이어그램을 추가했습니다.

### 스크린샷
<img width="1637" alt="스크린샷 2025-03-13 오후 9 47 02" src="https://github.com/user-attachments/assets/3647c279-0826-49ec-8a85-042d38f46f9a" />


<br/>

## 💬 리뷰 요구사항

- 원래 작업하던대로 Presentation, Domain, Data 레이어로 나누는 MVVM + CleanArchitecture로 설계를 해봤는데 변경 해야할 부분이 있을지 살펴봐주시면 감사하겠습니다. 
<br/>
   
## 👀 검토 시 주의사항

- ❌
<br/>

## 🔗 참고자료 및 관련 이슈

> [MVVM + Clean Architecture 참고](https://github.com/kudoleh/iOS-Clean-Architecture-MVVM)