### PR TITLE
[#16] Timer 도메인 모듈 생성

### DIFF
--- a/Domain/TimerDomain/Project.swift
+++ b/Domain/TimerDomain/Project.swift
@@ -1,0 +1,28 @@
+//
+//  project.stencil
+//  Config
+//
+//  Created by JUNHEE JO on 4/1/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeModule(
+    name: "TimerDomain",
+    moduleLayer: .domain,
+    targets: [
+        .interface,
+        .implementation,
+        .tests,
+        .testing
+    ],
+    dependencies: [
+        .implementation: [
+            .target(name: "TimerDomainInterface")
+        ],
+        .tests: [
+            .target(name: "TimerDomainImplementation")
+        ]
+    ]
+)

--- a/Domain/TimerDomain/Sources/Implementation/TimerDomainImplementation.swift
+++ b/Domain/TimerDomain/Sources/Implementation/TimerDomainImplementation.swift
@@ -1,0 +1,10 @@
+//
+//  DomainModuleFile.swift
+//  Config
+//
+//  Created by JUNHEE JO on 4/1/25.
+//
+
+// 이 파일은 scaffold로 생성시 디렉토리에 파일이 없으면 generate 되지 않는 문제를 해결하기 위한 파일입니다.
+// 실제 구현 시 교체하거나 삭제해도 됩니다.
+import Foundation

--- a/Domain/TimerDomain/Sources/Interface/TimerDomainInterface.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerDomainInterface.swift
@@ -1,0 +1,10 @@
+//
+//  DomainModuleFile.swift
+//  Config
+//
+//  Created by JUNHEE JO on 4/1/25.
+//
+
+// 이 파일은 scaffold로 생성시 디렉토리에 파일이 없으면 generate 되지 않는 문제를 해결하기 위한 파일입니다.
+// 실제 구현 시 교체하거나 삭제해도 됩니다.
+import Foundation

--- a/Domain/TimerDomain/Tests/Testing/TimerDomainTesting.swift
+++ b/Domain/TimerDomain/Tests/Testing/TimerDomainTesting.swift
@@ -1,0 +1,10 @@
+//
+//  DomainModuleFile.swift
+//  Config
+//
+//  Created by JUNHEE JO on 4/1/25.
+//
+
+// 이 파일은 scaffold로 생성시 디렉토리에 파일이 없으면 generate 되지 않는 문제를 해결하기 위한 파일입니다.
+// 실제 구현 시 교체하거나 삭제해도 됩니다.
+import Foundation

--- a/Domain/TimerDomain/Tests/UnitTests/TimerDomainTests.swift
+++ b/Domain/TimerDomain/Tests/UnitTests/TimerDomainTests.swift
@@ -1,0 +1,10 @@
+//
+//  DomainModuleFile.swift
+//  Config
+//
+//  Created by JUNHEE JO on 4/1/25.
+//
+
+// 이 파일은 scaffold로 생성시 디렉토리에 파일이 없으면 generate 되지 않는 문제를 해결하기 위한 파일입니다.
+// 실제 구현 시 교체하거나 삭제해도 됩니다.
+import Foundation

--- a/Tuist/Templates/Core/Core.swift
+++ b/Tuist/Templates/Core/Core.swift
@@ -30,10 +30,6 @@ let coreTemplate = Template(
         .file(
             path: "Core/{{ name }}/Tests/Testing/{{ name }}Testing.swift",
             templatePath: "CoreModuleFile.swift"
-        ),
-        .file(
-            path: "Core/{{ name }}/scripts/create_structure.sh",
-            templatePath: "scripts/create_structure.sh"
         )
     ]
 )

--- a/Tuist/Templates/Domain/Domain.swift
+++ b/Tuist/Templates/Domain/Domain.swift
@@ -33,11 +33,6 @@ let domainTemplate = Template(
         .file(
             path: "Domain/{{ name }}/Tests/Testing/{{ name }}Testing.swift",
             templatePath: "DomainModuleFile.swift"
-        ),
-
-        .file(
-            path: "Domain/{{ name }}/scripts/create_structure.sh",
-            templatePath: "scripts/create_structure.sh"
         )
     ]
 )

--- a/Tuist/Templates/Feature/Feature.swift
+++ b/Tuist/Templates/Feature/Feature.swift
@@ -42,10 +42,6 @@ let featureTemplate = Template(
         .file(
             path: "Feature/{{ name }}/Tests/Testing/{{ name }}Testing.swift",
             templatePath: "FeatureModuleFile.swift"
-        ),
-        .file(
-            path: "Feature/{{ name }}/scripts/create_structure.sh",
-            templatePath: "scripts/create_structure.sh"
         )
     ]
 )

--- a/Tuist/Templates/Shared/Shared.swift
+++ b/Tuist/Templates/Shared/Shared.swift
@@ -34,10 +34,6 @@ let sharedTemplate = Template(
         .file(
             path: "Shared/{{ name }}/Tests/Testing/{{ name }}Testing.swift",
             templatePath: "SharedModuleFile.swift"
-        ),
-        .file(
-            path: "Shared/{{ name }}/scripts/create_structure.sh",
-            templatePath: "scripts/create_structure.sh"
         )
     ]
 )

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -14,7 +14,7 @@ let workspace = Workspace(
         // TODO: 해당 모듈이 추가되면 주석을 해제해야합니다.
         // "Feature/**",
         // "Core/**",
-        // "Domain/**",
+        "Domain/**",
         // "Shared/**"
     ]
 )


### PR DESCRIPTION
## 📝 작업 내용
- scaffold를 이용해서 TimerDomain 모듈을 생성했습니다.

## 💬 리뷰 요구사항
- 이전에 프로젝트가 하나이고 나머지 모듈들을 framwork로해서 의존성을 가지게 만드는 방식은 어떠냐고 말씀하셨는데 관련해서 내용을 찾아봤습니다!
- Tuist 문서에서 workspace로 구성할때 모듈별로 proeject.swift를 workspace에서 묶는거를 스탠다드로 보고있는거 같습니다.
- 자료가 많지않지만 몇몇 tuist를 사용하는 예시, 컨퍼런스를 찾아보면 workspace안에 모듈마다 프로젝트를 가지고 있는 모습을 확인할 수 있었습니다.
- 모듈별로 프로젝트를 나누면 각 프로젝트마다 빌드 ,테스트가 가능하고 프로젝트 단위로 의존성을 쉽게 확인가능하며 특정 모듈의 코드가 수정됐을때 해당 모듈만 빌드하면 되니까 이렇게 사용하는게 아닐까 라는 생각인데 하나의 프로젝트에 나머지 모듈을 프레임워크로 의존하도록 만들면 이런 이점을 그대로 가져갈 수 있는지는 확인해보지 않아서 잘 모르겠네요.
<br/>
   
## 👀 검토 시 주의사항
- scaffold로 생성시 기본 파일이 들어가 있습니다. 이 파일들을 `tuist generate`가 성공하기 위한 파일이기때문에 이후에 변경되거나 삭제될 예정입니다.
<br/>

## 🔗 참고자료 및 관련 이슈
> [Tuist 문서](https://docs.tuist.dev/en/guides/develop/projects/directory-structure)
> [모듈 분리 설명이 잘 되어 있는 국내 컨퍼런스 자료](https://youtu.be/Up0wYoyY3o0?si=6QGWIEr5KoHFuCQy)