### PR TITLE
[#24] 도메인 계층 타이머 관련 핵심 프로토콜 추가

### DIFF
--- a/Domain/TimerDomain/Sources/Interface/TimerControllable.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerControllable.swift
@@ -1,0 +1,30 @@
+//
+//  TimerControllable.swift
+//  TimerDomainInterface
+//
+//  Created by JUNHEE JO on 4/24/25.
+//
+
+import Foundation
+import Combine
+
+/// 타이머의 실행 상태를 제어하고 남은 시간을 외부에 스트리밍할 수 있도록 추상화한 프로토콜입니다.
+public protocol TimerControllable {
+    /// 타이머를 처음부터 시작합니다.
+    /// - Parameter duration: 타이머 전체 실행 시간(초)
+    func start(duration: Int)
+
+    /// 일시 정지된 타이머를 다시 시작합니다.
+    /// 현재 남은 시간을 기준으로 재개됩니다.
+    /// - Parameter remainingTime: 타이머 남은 실행 시간(초)
+    func resume(remainingTime: Int)
+
+    /// 타이머를 일시 정지합니다.
+    func stop()
+
+    /// 타이머를 초기 상태로 되돌립니다.
+    func reset()
+
+    /// 남은 시간을 1초 단위로 발행하는 Publisher입니다.
+    var remainingTime: AnyPublisher<Int, Never> { get }
+}

--- a/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
@@ -1,0 +1,14 @@
+//
+//  TimerRepository.swift
+//  TimerDomainInterface
+//
+//  Created by JUNHEE JO on 4/24/25.
+//
+
+import Foundation
+
+public protocol TimerRepository {
+    func saveTime(_ timer: Timer)
+    func loadTimer() -> Timer
+    func clearTimer()
+}

--- a/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public protocol TimerRepository {
-    func saveTime(_ timer: Timer)
-    func loadTimer() -> Timer
-    func clearTimer()
+    func save(_ timer: Timer)
+    func load() -> Timer?
+    func clear()
 }

--- a/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerRepository.swift
@@ -7,8 +7,17 @@
 
 import Foundation
 
+/// 도메인 타이머(Timer)의 상태를 저장, 불러오기, 초기화하는 추상 저장소 인터페이스입니다.
 public protocol TimerRepository {
+
+    /// 타이머 상태를 저장합니다.
+    /// - Parameter timer: 저장할  타이머 인스턴스
     func save(_ timer: Timer)
+
+    /// 저장된 타이머 상태를 불러옵니다.
+    /// - Returns: 마지막으로 저장된 타이머 객체. 값이 없는 경우 nil 반환
     func load() -> Timer?
+
+    /// 저장된 타이머 상태를 초기화합니다.
     func clear()
 }


### PR DESCRIPTION
## 📝 작업 내용
- 타이머 상태를 저장, 불러오기, 초기화하는 책임을 가지는 `TimerRepository` 프로토콜 추가
- 타이머의 실행 흐름(시작, 일시정지, 재개, 초기화)을 제어하는 책임을 가지는 `TimerControllable` 프로토콜 추가
<br/>

## 💬 리뷰 요구사항
- `TimerRepository` 설계시 비동기 처리 방식에 대한 고민
  - 기존에 제가 자주 사용하던 RxSwift를 이용했다면 save, clear는 Completable, load는 Single<Timer>로 구현했을 것 같습니다.
  - Combine에서는 이와 비슷하게 `Publisher`를 반환하는 방법으로 구현할지 고민했었습니다. 그러다 이러한 단발성 비동기 작업은 async/await을 적용하는게 더 좋을거 같다는 생각을 했습니다.
  - 하지만 아직 async/await를 제대로 공부하지 않았고 이러한 생각이 괜찮은 방향인지 고민이 들어서 일단은 특별한 비동기 처리가 없는 프로토콜을 작성했습니다.
  - 이러한 작업에서는 스트림을 리턴하는 방식보다 async/await를 사용하는 방향이 적절한지 의견을 듣고 싶습니다!

- `TimerControllable` 설계
  - start와 resume, stop과 reset을 명확히 구분하는 방향으로 나누었지만
  - 실제로 Controllable 객체에 resume, reset이 꼭 필요한지에 대해서는 이후 구현을 진행하며 다시 검토해볼 예정입니다.
  - 현재는 의도를 명확하게하기 위해 일단 start/resume/stop/reset 모두 구분해서 프로토콜을 작성했습니다.
  - 하지만 이후에 구현부를 구현할때 타이머의 흐름을 다룰때 start과 resume이 stop과 reset이 구현의 차이가 없을거 같다는 생각이 들었습니다.
  - 이러한 메서드 분리가 과도한지? 아니면 의도를 명확하게 표현하는 데 의미가 있다고 볼 수 있는지 의견 부탁드립니다.

- TimerControllable에서 `remainingTime`은 시간에 따라 지속적으로 변하는 데이터를 스트림으로 처리하기 위해 Combine을 사용했습니다.
  - 다만, start, resume, stop, reset 등의 메서드는 Timer의 상태만 변경하는 작업이므로 별도의 비동기 처리는 필요하지 않다고 생각했습니다.
  - 따라서 Repository에서 고민했던 비동기 반환 방식(Publisher 또는 async/await)은 적용하지 않았습니다.
  - 이러한 생각에 대해서도 의견을 듣고 싶습니다.
   
## 👀 검토 시 주의사항
- `TimerControllable`에서도 stop보다 pause의 의미가 맞다고 생각하여 이후 PR(#31)에서 pause로 변경했습니다.
-  TimerRepository는 SwiftData를 활용할 예정이며, 이후 async/await 리팩터링도 계획하고 있습니다.
<br/>

## 🔗 참고자료 및 관련 이슈
- #31 