### PR TITLE
[#30] TimerState의 isRunning 프로퍼티를 enum으로 변경

### DIFF
--- a/Domain/TimerDomain/Sources/Interface/TimerPhase.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerPhase.swift
@@ -1,0 +1,15 @@
+//
+//  TimerPhase.swift
+//  TimerDomainInterface
+//
+//  Created by JUNHEE JO on 4/27/25.
+//
+
+import Foundation
+
+public enum TimerPhase {
+    case ready
+    case active
+    case paused
+    case completed
+}

--- a/Domain/TimerDomain/Sources/Interface/TimerState.swift
+++ b/Domain/TimerDomain/Sources/Interface/TimerState.swift
@@ -11,17 +11,17 @@ public struct TimerState {
     // MARK: - Properties
     public let duration: Int
     public let remainingTime: Int
-    public let isRunning: Bool
+    public let phase: TimerPhase
 
     // MARK: - Initialization
     public init(
         duration: Int,
         remainingTime: Int? = nil,
-        isRunning: Bool = false
+        phase: TimerPhase = .ready
     ) {
         self.duration = duration
         self.remainingTime = remainingTime ?? duration
-        self.isRunning = isRunning
+        self.phase = phase
     }
 
     // MARK: - State Changes
@@ -30,7 +30,7 @@ public struct TimerState {
         TimerState(
             duration: self.duration,
             remainingTime: self.remainingTime,
-            isRunning: true
+            phase: .active
         )
     }
 
@@ -39,17 +39,18 @@ public struct TimerState {
         TimerState(
             duration: self.duration,
             remainingTime: self.remainingTime,
-            isRunning: false
+            phase: .paused
         )
     }
 
     /// 남은 시간 업데이트
     public func updateRemainingTime(_ newTime: Int) -> TimerState {
         let clampedTime = max(0, min(newTime, duration))
+        let newPhase = clampedTime == 0 ? TimerPhase.completed : self.phase
         return TimerState(
             duration: self.duration,
             remainingTime: clampedTime,
-            isRunning: self.isRunning
+            phase: newPhase
         )
     }
 
@@ -58,7 +59,7 @@ public struct TimerState {
         TimerState(
             duration: self.duration,
             remainingTime: self.duration,
-            isRunning: false
+            phase: .ready
         )
     }
 }
@@ -70,6 +71,6 @@ extension TimerState: Hashable {}
 // MARK: - Custom String Convertible
 extension TimerState: CustomStringConvertible {
     public var description: String {
-        "TimerState(duration: \(duration)s, remaining: \(remainingTime)s, running: \(isRunning))"
+        "TimerState(duration: \(duration)s, remaining: \(remainingTime)s, phase: \(phase))"
     }
 }

--- a/Domain/TimerDomain/Tests/UnitTests/TimerStateTests.swift
+++ b/Domain/TimerDomain/Tests/UnitTests/TimerStateTests.swift
@@ -10,34 +10,34 @@ import XCTest
 
 final class TimerStateTests: XCTestCase {
     // MARK: - start()
-    func testStart_shouldReturnTimerStateWithRunningTrue() {
+    func testStart_shouldReturnTimerStateWithPhaseActive() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 30, isRunning: false)
+        let timerState = TimerState(duration: 60, remainingTime: 30, phase: .ready)
 
         // When
         let started = timerState.start()
 
         // Then
-        XCTAssertTrue(started.isRunning)
+        XCTAssertEqual(started.phase, .active)
         XCTAssertEqual(started.duration, 60)
         XCTAssertEqual(started.remainingTime, 30)
     }
 
     // MARK: - pause()
-    func testPause_shouldReturnTimerStateWithRunningFalse() {
+    func testPause_shouldReturnTimerStateWithPhasePaused() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 10, isRunning: true)
+        let timerState = TimerState(duration: 60, remainingTime: 10, phase: .active)
 
         // When
         let paused = timerState.pause()
 
         // Then
-        XCTAssertFalse(paused.isRunning)
+        XCTAssertEqual(paused.phase, .paused)
     }
 
     func testPause_shouldPreserveRemainingTime() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 10, isRunning: true)
+        let timerState = TimerState(duration: 60, remainingTime: 10, phase: .active)
 
         // When
         let stopped = timerState.pause()
@@ -49,7 +49,7 @@ final class TimerStateTests: XCTestCase {
     // MARK: - reset()
     func testReset_shouldReturnTimerStateWithRemainingTimeEqualsDuration() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 15, isRunning: true)
+        let timerState = TimerState(duration: 60, remainingTime: 15, phase: .active)
 
         // When
         let reset = timerState.reset()
@@ -58,48 +58,63 @@ final class TimerStateTests: XCTestCase {
         XCTAssertEqual(reset.remainingTime, 60)
     }
 
-    func testReset_shouldReturnTimerStateWithRunningFalse() {
+    func testReset_shouldReturnTimerStateWithPhaseReady() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 15, isRunning: true)
+        let timerState = TimerState(duration: 60, remainingTime: 15, phase: .active)
 
         // When
         let reset = timerState.reset()
 
         // Then
-        XCTAssertFalse(reset.isRunning)
+        XCTAssertEqual(reset.phase, .ready)
     }
 
     // MARK: - updateRemainingTime()
     func testUpdateRemainingTime_shouldClampAboveMaxToDuration() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 30)
+        let timerState = TimerState(duration: 60, remainingTime: 30, phase: .active)
 
         // When
         let updated = timerState.updateRemainingTime(100)
 
         // Then
         XCTAssertEqual(updated.remainingTime, 60)
+        XCTAssertEqual(updated.phase, .active)
     }
 
     func testUpdateRemainingTime_shouldClampBelowMinToZero() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 30)
+        let timerState = TimerState(duration: 60, remainingTime: 30, phase: .active)
 
         // When
         let updated = timerState.updateRemainingTime(-10)
 
         // Then
         XCTAssertEqual(updated.remainingTime, 0)
+        XCTAssertEqual(updated.phase, .completed)
     }
 
     func testUpdateRemainingTime_shouldSetExactValueWithinBounds() {
         // Given
-        let timerState = TimerState(duration: 60, remainingTime: 30)
+        let timerState = TimerState(duration: 60, remainingTime: 30, phase: .active)
 
         // When
         let updated = timerState.updateRemainingTime(25)
 
         // Then
         XCTAssertEqual(updated.remainingTime, 25)
+        XCTAssertEqual(updated.phase, .active)
+    }
+    
+    func testUpdateRemainingTime_shouldChangePhaseToCompletedWhenTimeReachesZero() {
+        // Given
+        let timerState = TimerState(duration: 60, remainingTime: 5, phase: .active)
+        
+        // When
+        let updated = timerState.updateRemainingTime(0)
+        
+        // Then
+        XCTAssertEqual(updated.remainingTime, 0)
+        XCTAssertEqual(updated.phase, .completed)
     }
 }


### PR DESCRIPTION
## 📝 작업 내용\
- `isRunning: Bool`을 `phase: TimerPhase` 로 변경
<br/>

## 💬 리뷰 요구사항
- isRunning: Bool 대신 TimerPhase enum으로 상태를 관리하는 방식이 이후 확장성과 상태의 명확성 면에서 좋다고 생각하여 변경했습니다.
- 그런데 TimerPhase 라는 이름이 TimerState와 혼동의 여지가 있지않을까? 라는 생각도듭니다.
- TimerPhase에는 4가지 케이스(ready, active, paused, completed)를 정의했습니다. 시작전, 동작, 일시정지, 완료만 있으면 뽀모도로 타이머에서 원하는 기능들을 구현할 수 있을거라고 판단해서 4가지만 정의했습니다.
- 더 명확하거나 적절한 방식이 있었을지? 아니면 이러한 확장 방향이 불필요 했을지? 말씀해주시면 감사하겠습니다.
- 멘토님이라면 이 타이머 상태를 어떻게 설계하셨을지 궁금합니다. 조언을 해주시면 큰 도움이 될 것 같습니다!
<br/>
   
## 👀 검토 시 주의사항
- ❌
<br/>

## 🔗 참고자료 및 관련 이슈
> #30 